### PR TITLE
table이 깨지는 현상 fix

### DIFF
--- a/plugins/kboard/class/KBoardBuilder.class.php
+++ b/plugins/kboard/class/KBoardBuilder.class.php
@@ -163,9 +163,11 @@ class KBoardBuilder {
 			if(!$board->use_editor && $this->meta->autolink){
 				include KBOARD_DIR_PATH . '/helper/Autolink.helper.php';
 				$content->content = nl2br(Kboard_autolink($content->content));
+				$content->content = preg_replace("/(<(|\/)(table|th|tr|td).*>)(<br \/>)/","\$1", $content->content);
 			}
 			else{
 				$content->content = nl2br($content->content);
+				$content->content = preg_replace("/(<(|\/)(table|th|tr|td).*>)(<br \/>)/","\$1", $content->content);
 			}
 			
 			// 게시글 숏코드(Shortcode) 실행


### PR DESCRIPTION
nl2br 함수가 table 관련 태그에는 br을 붙이지 않도록 개선, dom 및 레이아웃 깨지는 문제 fix

table, th, tr, td에만 예외 처리시켰습니다
