### PR TITLE
jQuery.fn 으로 확장하는 함수끼리의 충돌 막기

### DIFF
--- a/plugins/kboard-comments/skin/default/script.js
+++ b/plugins/kboard-comments/skin/default/script.js
@@ -3,12 +3,12 @@
  */
 
 var console = window.console || { log: function() {} };
-jQuery.fn.exists = function(){
-	return this.length>0;
-}
 
 function kboard_comments_execute(form){
-	var $ = jQuery;
+	var $ = jQuery.noConflict();
+	jQuery.fn.exists = function(){
+		return this.length>0;
+	};
 	
 	if($('input[name=member_display]', form).exists() && !$('input[name=member_display]', form).val()){
 		alert(kboard_comments_localize.please_enter_a_author);

--- a/plugins/kboard/skin/avatar/script.js
+++ b/plugins/kboard/skin/avatar/script.js
@@ -3,12 +3,12 @@
  */
 
 var console = window.console || { log: function() {} };
-jQuery.fn.exists = function(){
-	return this.length>0;
-}
 
 function kboard_editor_execute(form){
-	var $ = jQuery;
+	var $ = jQuery.noConflict();
+	jQuery.fn.exists = function(){
+		return this.length>0;
+	};
 	
 	if(!$('input[name=title]', form).val()){
 		alert(kboard_localize.please_enter_a_title);

--- a/plugins/kboard/skin/customer/script.js
+++ b/plugins/kboard/skin/customer/script.js
@@ -3,12 +3,12 @@
  */
 
 var console = window.console || { log: function() {} };
-jQuery.fn.exists = function(){
-	return this.length>0;
-}
 
 function kboard_editor_execute(form){
-	var $ = jQuery;
+	var $ = jQuery.noConflict();
+	jQuery.fn.exists = function(){
+		return this.length>0;
+	};
 	
 	if(!$('input[name=title]', form).val()){
 		alert(kboard_localize.please_enter_a_title);

--- a/plugins/kboard/skin/default/script.js
+++ b/plugins/kboard/skin/default/script.js
@@ -3,12 +3,12 @@
  */
 
 var console = window.console || { log: function() {} };
-jQuery.fn.exists = function(){
-	return this.length>0;
-}
 
 function kboard_editor_execute(form){
-	var $ = jQuery;
+	var $ = jQuery.noConflict();
+	jQuery.fn.exists = function(){
+		return this.length>0;
+	};
 	
 	if(!$('input[name=title]', form).val()){
 		alert(kboard_localize.please_enter_a_title);

--- a/plugins/kboard/skin/thumbnail/script.js
+++ b/plugins/kboard/skin/thumbnail/script.js
@@ -3,12 +3,12 @@
  */
 
 var console = window.console || { log: function() {} };
-jQuery.fn.exists = function(){
-	return this.length>0;
-}
 
 function kboard_editor_execute(form){
-	var $ = jQuery;
+	var $ = jQuery.noConflict();
+	jQuery.fn.exists = function(){
+		return this.length>0;
+	};
 	
 	if(!$('input[name=title]', form).val()){
 		alert(kboard_localize.please_enter_a_title);


### PR DESCRIPTION
#6 이슈의 관한 수정사항입니다.

jQuery.fn.exists 로 확장해서 사용하는 부분을 다른 라이브러이와 충돌이 일어나지 않도록 수정했습니다.

충돌 예)
https://mythemeshop.com/themes/glamour/
https://mythemeshop.com/wp-content/themes/mythemeshopfeb25/js/customscript.min.js?ver=4.1.1
위 스크립트에서도 jQuery.fn.exists를 확장해서 사용하는데 KBoard의 script.js에서 그 처리가 제대로 되어있지 않네요.

