### PR TITLE
Update KBController.class.php

### DIFF
--- a/plugins/kboard/class/KBController.class.php
+++ b/plugins/kboard/class/KBController.class.php
@@ -8,7 +8,7 @@
 class KBController {
 	
 	public function __construct(){
-		header("Content-Type: text/html; charset=UTF-8");
+		//header("Content-Type: text/html; charset=UTF-8");
 	}
 	
 	public function init(){


### PR DESCRIPTION
KBoard 플러그인이 활성화 되면서 테마내에 custom.css.php 와 같은 php로 로드되는 html/text 이외의 양식들이 여기 헤더에 선언된 파라미터 때문에 인식이 안되는 문제가 있습니다. 이에 코드 삭제부탁드립니다.