### PR TITLE
Fix: getOptionValue 인자값의 잘못된 변수명 사용

### DIFF
--- a/plugins/kboard/class/KBContent.class.php
+++ b/plugins/kboard/class/KBContent.class.php
@@ -775,7 +775,7 @@ class KBContent {
 	 * @return string|array
 	 */
 	public function getOptionValue($option_name){
-		return $this->option->{$key};
+		return $this->option->{$option_name};
 	}
 	
 	/**


### PR DESCRIPTION
커스터마이징 중

확장 필드를 사용했을 때 필요한 getOptionValue의 버그를 발견하여

머지 요청합니다!